### PR TITLE
Add module level options

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+# dev
+  * Command line arguments (such as `--randomize-order`) can now be overridden on a per-module basis ([25](https://github.com/martijnbastiaan/doctest-parallel/pull/25))
+
 # 0.2.1
   * C include directories (Cabal field: `include-dirs`) are now passed to GHC when parsing source files ([#7](https://github.com/martijnbastiaan/doctest-parallel/issues/7))
   * A migration guide has been added ([#11](https://github.com/martijnbastiaan/doctest-parallel/issues/11))

--- a/README.markdown
+++ b/README.markdown
@@ -289,6 +289,14 @@ You _hide_ the import of `Prelude` by using:
 -- >>> :m -Prelude
 ```
 
+## Per module options
+You can override command line flags per module by using a module annotation. For example, if you know a specific module does not support test order randomization, you can disabled it with:
+
+```haskell
+{-# ANN module "--no-randomize-order" #-}
+```
+
+
 # Relation to [`doctest`](https://github.com/sol/doctest)
 This is a fork of [sol/doctest](https://github.com/sol/doctest) that allows running tests in parallel and aims to provide a more robust project integration method. It is not backwards compatible and expects to be setup differently. At the time of writing it has a few advantages over the base project:
 

--- a/doctest-parallel.cabal
+++ b/doctest-parallel.cabal
@@ -40,6 +40,7 @@ extra-source-files:
     test/extract/export-list/*.hs
     test/extract/imported-module/*.hs
     test/extract/module-header/*.hs
+    test/extract/module-options/*.hs
     test/extract/named-chunks/*.hs
     test/extract/regression/*.hs
     test/extract/setup/*.hs
@@ -93,6 +94,7 @@ library
     , deepseq
     , directory
     , exceptions
+    , extra
     , filepath
     , ghc >=8.4 && <9.3
     , ghc-paths >=0.1.0.9
@@ -139,6 +141,7 @@ library spectests-modules
     LocalStderrBinding.A
     ModuleIsolation.TestA
     ModuleIsolation.TestB
+    ModuleOptions.Foo
     Multiline.Multiline
     PropertyBool.Foo
     PropertyBoolWithTypeSignature.Foo

--- a/example/README.md
+++ b/example/README.md
@@ -43,7 +43,7 @@ main = mainFromCabal "your-project" =<< getArgs
 Execute:
 
 ```
-cabal run doctests -- arg1 arg2
+cabal run doctests
 ```
 
 **At the moment, using `cabal test` is not reliable. See [#22](https://github.com/martijnbastiaan/doctest-parallel/issues/22).**
@@ -52,5 +52,51 @@ cabal run doctests -- arg1 arg2
 Stack users can use:
 
 ```
-stack test
+stack test example:doctestsstack test
+```
+
+It will also run as part of `stack test`.
+
+# Help
+Run:
+
+```
+cabal run doctests -- --help
+```
+
+Or:
+
+```
+stack test example:doctests --test-arguments --help
+```
+
+Example output:
+
+```
+Usage:
+  doctest [ options ]... [<module>]...
+  doctest --help
+  doctest --version
+  doctest --info
+
+Options:
+   -jN                      number of threads to use
+†  --randomize-order        randomize order in which tests are run
+†  --seed=N                 use a specific seed to randomize test order
+†  --preserve-it            preserve the `it` variable between examples
+   --verbose                print each test as it is run
+   --quiet                  only print errors
+   --help                   display this help and exit
+   --version                output version information and exit
+   --info                   output machine-readable version information and exit
+
+Supported inverted options:
+†  --no-randomize-order (default)
+†  --no-preserve-it (default)
+
+Options marked with a dagger (†) can also be used to set module level options, using
+an ANN pragma like this:
+
+  {-# ANN module "doctest-parallel: --no-randomize-order" #-}
+
 ```

--- a/src/Test/DocTest/Internal/Parse.hs
+++ b/src/Test/DocTest/Internal/Parse.hs
@@ -56,17 +56,19 @@ getDocTests args = parseModules <$> extract args
 
 parseModules :: [Module (Located String)] -> [Module [Located DocTest]]
 parseModules = filter (not . isEmpty) . map parseModule
-  where
-    isEmpty (Module _ setup tests) = null tests && isNothing setup
+ where
+  isEmpty (Module _ setup tests _) = null tests && isNothing setup
 
 -- | Convert documentation to `Example`s.
 parseModule :: Module (Located String) -> Module [Located DocTest]
-parseModule m = case parseComment <$> m of
-  Module name setup tests -> Module name setup_ (filter (not . null) tests)
-    where
-      setup_ = case setup of
-        Just [] -> Nothing
-        _       -> setup
+parseModule m =
+  case parseComment <$> m of
+    Module name setup tests cfg ->
+      Module name setup_ (filter (not . null) tests) cfg
+      where
+        setup_ = case setup of
+          Just [] -> Nothing
+          _       -> setup
 
 parseComment :: Located String -> [Located DocTest]
 parseComment c = properties ++ examples

--- a/test/ExtractSpec.hs
+++ b/test/ExtractSpec.hs
@@ -22,73 +22,96 @@ import           System.FilePath
 shouldGive :: HasCallStack => (String, String) -> [Module String] -> Assertion
 (d, m) `shouldGive` expected = do
   r <- map (fmap unLoc) `fmap` extract ["-i" ++ dir, dir </> m]
-  r `shouldBe` expected
-  where dir = "test/extract" </> d
+  map eraseConfigLocation r `shouldBe` map eraseConfigLocation expected
+ where
+  dir = "test/extract" </> d
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
 spec = do
+  let mod_ nm content = Module nm Nothing content []
 
   describe "extract" $ do
     it "extracts documentation for a top-level declaration" $ do
-      ("declaration", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" Some documentation"]]
+      ("declaration", "Foo.hs") `shouldGive` [mod_ "Foo" [" Some documentation"]]
 
     it "extracts documentation from argument list" $ do
-      ("argument-list", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" doc for arg1", " doc for arg2"]]
+      ("argument-list", "Foo.hs") `shouldGive` [mod_ "Foo" [" doc for arg1", " doc for arg2"]]
 
     it "extracts documentation for a type class function" $ do
-      ("type-class", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" Convert given value to a string."]]
+      ("type-class", "Foo.hs") `shouldGive` [mod_ "Foo" [" Convert given value to a string."]]
 
     it "extracts documentation from the argument list of a type class function" $ do
-      ("type-class-args", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" foo", " bar"]]
+      ("type-class-args", "Foo.hs") `shouldGive` [mod_ "Foo" [" foo", " bar"]]
 
     it "extracts documentation from the module header" $ do
-      ("module-header", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" Some documentation"]]
+      ("module-header", "Foo.hs") `shouldGive` [mod_ "Foo" [" Some documentation"]]
 
     it "extracts documentation from imported modules" $ do
-      ("imported-module", "Bar.hs") `shouldGive` [Module "Bar" Nothing [" documentation for bar"], Module "Baz" Nothing [" documentation for baz"]]
+      ("imported-module", "Bar.hs") `shouldGive` [mod_ "Bar" [" documentation for bar"], mod_ "Baz" [" documentation for baz"]]
 
     it "extracts documentation from export list" $ do
-      ("export-list", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" documentation from export list"]]
+      ("export-list", "Foo.hs") `shouldGive` [mod_ "Foo" [" documentation from export list"]]
 
     it "extracts documentation from named chunks" $ do
-      ("named-chunks", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" named chunk foo", "\n named chunk bar"]]
+      ("named-chunks", "Foo.hs") `shouldGive` [mod_ "Foo" [" named chunk foo", "\n named chunk bar"]]
 
     it "returns docstrings in the same order they appear in the source" $ do
-      ("comment-order", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" module header", " export list 1", " export list 2", " foo", " named chunk", " bar"]]
+      ("comment-order", "Foo.hs") `shouldGive` [mod_ "Foo" [" module header", " export list 1", " export list 2", " foo", " named chunk", " bar"]]
 
     it "extracts $setup code" $ do
-      ("setup", "Foo.hs") `shouldGive` [Module "Foo" (Just "\n some setup code") [" foo", " bar", " baz"]]
+      ("setup", "Foo.hs") `shouldGive` [(mod_ "Foo"  [" foo", " bar", " baz"]){moduleSetup=Just "\n some setup code"}]
 
     it "fails on invalid flags" $ do
       extract ["--foobar", "test/Foo.hs"] `shouldThrow` (\e -> case e of UsageError "unrecognized option `--foobar'" -> True; _ -> False)
 
   describe "extract (regression tests)" $ do
     it "works with infix operators" $ do
-      ("regression", "Fixity.hs") `shouldGive` [Module "Fixity" Nothing []]
+      ("regression", "Fixity.hs") `shouldGive` [mod_ "Fixity" []]
 
     it "works with parallel list comprehensions" $ do
-      ("regression", "ParallelListComp.hs") `shouldGive` [Module "ParallelListComp" Nothing []]
+      ("regression", "ParallelListComp.hs") `shouldGive` [mod_ "ParallelListComp" []]
 
     it "works with list comprehensions in instance definitions" $ do
-      ("regression", "ParallelListCompClass.hs") `shouldGive` [Module "ParallelListCompClass" Nothing []]
+      ("regression", "ParallelListCompClass.hs") `shouldGive` [mod_ "ParallelListCompClass" []]
 
     it "works with foreign imports" $ do
-      ("regression", "ForeignImport.hs") `shouldGive` [Module "ForeignImport" Nothing []]
+      ("regression", "ForeignImport.hs") `shouldGive` [mod_ "ForeignImport" []]
 
     it "works for rewrite rules" $ do
-      ("regression", "RewriteRules.hs") `shouldGive` [Module "RewriteRules" Nothing [" doc for foo"]]
+      ("regression", "RewriteRules.hs") `shouldGive` [mod_ "RewriteRules" [" doc for foo"]]
 
     it "works for rewrite rules with type signatures" $ do
-      ("regression", "RewriteRulesWithSigs.hs") `shouldGive` [Module "RewriteRulesWithSigs" Nothing [" doc for foo"]]
+      ("regression", "RewriteRulesWithSigs.hs") `shouldGive` [mod_ "RewriteRulesWithSigs" [" doc for foo"]]
 
     it "strips CR from dos line endings" $ do
-      ("dos-line-endings", "Foo.hs") `shouldGive` [Module "Foo" Nothing ["\n foo\n bar\n baz"]]
+      ("dos-line-endings", "Foo.hs") `shouldGive` [mod_ "Foo" ["\n foo\n bar\n baz"]]
 
     it "works with a module that splices in an expression from an other module" $ do
-      ("th", "Foo.hs") `shouldGive` [Module "Foo" Nothing [" some documentation"], Module "Bar" Nothing []]
+      ("th", "Foo.hs") `shouldGive` [mod_ "Foo" [" some documentation"], mod_ "Bar" []]
 
     it "works for type families and GHC 7.6.1" $ do
-      ("type-families", "Foo.hs") `shouldGive` [Module "Foo" Nothing []]
+      ("type-families", "Foo.hs") `shouldGive` [mod_ "Foo" []]
+
+    it "ignores binder annotations" $ do
+      ("module-options", "Binders.hs") `shouldGive` [mod_ "Binders" []]
+
+    it "ignores module annotations that don't start with 'doctest-parallel:'" $ do
+      ("module-options", "NoOptions.hs") `shouldGive` [mod_ "NoOptions" []]
+
+    it "detects monomorphic module settings" $ do
+      ("module-options", "Mono.hs") `shouldGive` [(mod_ "Mono" []){moduleConfig=
+        [ noLocation "--no-randomize-error1"
+        , noLocation "--no-randomize-error2"
+        , noLocation "--no-randomize-error3"
+        , noLocation "--no-randomize-error4"
+        , noLocation "--no-randomize-error5"
+        , noLocation "--no-randomize-error6"
+        ]}]
+
+    it "detects polypormphic module settings" $ do
+      ("module-options", "Poly.hs") `shouldGive` [(mod_ "Poly" []){moduleConfig=
+        [ noLocation "--no-randomize-error"
+        ]}]

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -53,11 +53,11 @@ spec = do
         (cases 1)
 
     it "it-variable" $ do
-      doctestWithOpts (defaultConfig{cfgPreserveIt=True}) ["It.Foo"]
+      doctestWithOpts (defaultConfig{cfgModuleConfig=defaultModuleConfig{cfgPreserveIt=True}}) ["It.Foo"]
         (cases 5)
 
     it "it-variable in $setup" $ do
-      doctestWithOpts (defaultConfig{cfgPreserveIt=True}) ["It.Setup"]
+      doctestWithOpts (defaultConfig{cfgModuleConfig=defaultModuleConfig{cfgPreserveIt=True}}) ["It.Setup"]
         (cases 2)
 
     it "failing" $ do
@@ -176,3 +176,7 @@ spec = do
     it "correctly handles C import directories" $ do
       doctest ["WithCInclude.Bar"]
         (cases 1)
+
+    it "sets module level options" $ do
+      doctest ["ModuleOptions.Foo"]
+        (cases 5)

--- a/test/OptionsSpec.hs
+++ b/test/OptionsSpec.hs
@@ -13,11 +13,34 @@ spec = do
     describe "--preserve-it" $ do
       context "without --preserve-it" $ do
         it "does not preserve the `it` variable" $ do
-          cfgPreserveIt <$> parseOptions [] `shouldBe` Result False
+          cfgPreserveIt . cfgModuleConfig <$>
+            parseOptions [] `shouldBe` Result False
 
       context "with --preserve-it" $ do
         it "preserves the `it` variable" $ do
-          cfgPreserveIt <$> parseOptions ["--preserve-it"] `shouldBe` Result True
+          cfgPreserveIt . cfgModuleConfig <$>
+            parseOptions ["--preserve-it"] `shouldBe` Result True
+
+      context "with --no-preserve-it" $ do
+        it "preserves the `it` variable" $ do
+          cfgPreserveIt . cfgModuleConfig <$>
+            parseOptions ["--no-preserve-it"] `shouldBe` Result False
+
+    describe "--randomize-order" $ do
+      context "without --randomize-order" $ do
+        it "does not set randomize order" $ do
+          cfgRandomizeOrder . cfgModuleConfig <$>
+            parseOptions [] `shouldBe` Result False
+
+      context "with --randomize-order" $ do
+        it "sets randomize order" $ do
+          cfgRandomizeOrder . cfgModuleConfig <$>
+            parseOptions ["--randomize-order"] `shouldBe` Result True
+
+      context "with --no-randomize-order" $ do
+        it "unsets randomize order" $ do
+          cfgRandomizeOrder . cfgModuleConfig <$>
+            parseOptions ["--no-randomize-order"] `shouldBe` Result False
 
     context "with --help" $ do
       it "outputs usage information" $ do

--- a/test/ParseSpec.hs
+++ b/test/ParseSpec.hs
@@ -22,7 +22,7 @@ prop_ :: Expression -> Writer [DocTest] ()
 prop_ e = tell [Property e]
 
 module_ :: String -> Writer [[DocTest]] () -> Writer [Module [DocTest]] ()
-module_ name gs = tell [Module name Nothing $ execWriter gs]
+module_ name gs = tell [Module name Nothing (execWriter gs) []]
 
 shouldGive :: IO [Module [Located DocTest]] -> Writer [Module [DocTest]] () -> Expectation
 shouldGive action expected = map (fmap $ map unLoc) `fmap` action `shouldReturn` execWriter expected
@@ -82,7 +82,7 @@ spec = do
 
     it "keeps modules that only contain setup code" $ do
       getDocTests ["test/parse/setup-only/Foo.hs"] `shouldGive` do
-        tell [Module "Foo" (Just [Example "foo" ["23"]]) []]
+        tell [Module "Foo" (Just [Example "foo" ["23"]]) [] []]
 
   describe "parseInteractions (an internal function)" $ do
 

--- a/test/extract/module-options/Binders.hs
+++ b/test/extract/module-options/Binders.hs
@@ -1,0 +1,5 @@
+module Binders where
+
+{-# ANN f "doctest-parallel: --no-randomize-error" #-}
+f :: a -> a
+f = id

--- a/test/extract/module-options/Mono.hs
+++ b/test/extract/module-options/Mono.hs
@@ -1,0 +1,8 @@
+module Mono where
+
+{-# ANN module "doctest-parallel: --no-randomize-error1" #-}
+{-# ANN module ("doctest-parallel: --no-randomize-error2") #-}
+{-# ANN module ("doctest-parallel: --no-randomize-error3"  ) #-}
+{-# ANN module ("doctest-parallel:   --no-randomize-error4"  ) #-}
+{-# ANN module ("doctest-parallel:   --no-randomize-error5   "  ) #-}
+{-# ANN module ("doctest-parallel: --no-randomize-error6" :: String) #-}

--- a/test/extract/module-options/NoOptions.hs
+++ b/test/extract/module-options/NoOptions.hs
@@ -1,0 +1,5 @@
+module NoOptions where
+
+{-# ANN module "doctest-parallel" #-}
+{-# ANN module "abc" #-}
+{-# ANN module "" #-}

--- a/test/extract/module-options/Poly.hs
+++ b/test/extract/module-options/Poly.hs
@@ -1,0 +1,5 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Poly where
+
+{-# ANN module ("doctest-parallel: --no-randomize-error" :: String) #-}

--- a/test/integration/ModuleOptions/Foo.hs
+++ b/test/integration/ModuleOptions/Foo.hs
@@ -1,0 +1,22 @@
+module ModuleOptions.Foo where
+
+{-# ANN module "doctest-parallel: --preserve-it" #-}
+
+-- |
+--
+-- >>> :t 'a'
+-- 'a' :: Char
+--
+-- >>> "foo"
+-- "foo"
+--
+-- >>> length it
+-- 3
+--
+-- >>> it * it
+-- 9
+--
+-- >>> :t it
+-- it :: Int
+--
+foo = undefined

--- a/test/integration/ModuleOptions/Setup.hs
+++ b/test/integration/ModuleOptions/Setup.hs
@@ -1,0 +1,23 @@
+module It.Setup where
+
+-- $setup
+-- >>> :t 'a'
+-- 'a' :: Char
+--
+-- >>> 42 :: Int
+-- 42
+--
+-- >>> it
+-- 42
+
+-- |
+--
+-- >>> it * it
+-- 1764
+foo = undefined
+
+-- |
+--
+-- >>> it * it
+-- 1764
+bar = undefined


### PR DESCRIPTION
Command-line options can now be overridden on a per-module basis by
using a module annotation:

    {-# ANN module "doctest-parallel: --no-randomize-order" #-}

Closes #19