### PR TITLE
Add --no-implicit-module-import

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,5 +1,6 @@
 # dev
-  * Command line arguments (such as `--randomize-order`) can now be overridden on a per-module basis ([25](https://github.com/martijnbastiaan/doctest-parallel/pull/25))
+  * Command line arguments (such as `--randomize-order`) can now be overridden on a per-module basis ([#25](https://github.com/martijnbastiaan/doctest-parallel/pull/25))
+  * Implicit pre-test module imports can now be disabled using `--no-implicit-module-import`. This can help to test functions from non-exposed modules ([#26](https://github.com/martijnbastiaan/doctest-parallel/pull/26))
 
 # 0.2.1
   * C include directories (Cabal field: `include-dirs`) are now passed to GHC when parsing source files ([#7](https://github.com/martijnbastiaan/doctest-parallel/issues/7))

--- a/README.markdown
+++ b/README.markdown
@@ -293,7 +293,22 @@ You _hide_ the import of `Prelude` by using:
 You can override command line flags per module by using a module annotation. For example, if you know a specific module does not support test order randomization, you can disable it with:
 
 ```haskell
-{-# ANN module "--no-randomize-order" #-}
+{-# ANN module "doctest-parallel: --no-randomize-order" #-}
+```
+
+## Test non-exposed modules
+Generally, `doctest-parallel` cannot test binders that are part of non-exposed modules, unless they are re-exported from exposed modules. By default `doctest-parallel` will fail to do so (and report an error message), because it doesn't track whether functions are re-exported in such a way. To test a re-exported function, add the following to the _non-exposed_ module:
+
+```haskell
+{-# ANN module "doctest-parallel: --no-implicit-module-import" #-}
+```
+
+This makes `doctest-parallel` omit the usual module import at the start of a test.
+
+Then, before a test -or in `$setup`- add:
+
+```haskell
+>>> import Exposed.Module (someFunction)
 ```
 
 
@@ -307,9 +322,8 @@ This is a fork of [sol/doctest](https://github.com/sol/doctest) that allows runn
  * A minor change: it does not count lines in setup blocks as test cases
  * A minor change: the testsuite has been ported to v2 commands
 
- There are two downsides to using this project:
+AFAIK there's only one downside to using this project:
 
- * Examples in non-exposed modules cannot be tested (but will nonetheless be detected and consequently fail)
  * Use of conditionals in a cabal file as well as CPP flags will be ignored (TODO?)
 
 All in all, you can expect `doctest-parallel` to run about 1 or 2 orders of magnitude faster than `doctest` for large projects.

--- a/doctest-parallel.cabal
+++ b/doctest-parallel.cabal
@@ -142,6 +142,7 @@ library spectests-modules
     ModuleIsolation.TestA
     ModuleIsolation.TestB
     ModuleOptions.Foo
+    NonExposedModule.Exposed
     Multiline.Multiline
     PropertyBool.Foo
     PropertyBoolWithTypeSignature.Foo
@@ -165,6 +166,8 @@ library spectests-modules
     TrailingWhitespace.Foo
     WithCbits.Bar
     WithCInclude.Bar
+  other-modules:
+    NonExposedModule.NoImplicitImport
 
 test-suite spectests
   main-is: Spec.hs

--- a/example/README.md
+++ b/example/README.md
@@ -81,6 +81,7 @@ Usage:
 
 Options:
    -jN                      number of threads to use
+†  --implicit-module-import import module before testing it (default)
 †  --randomize-order        randomize order in which tests are run
 †  --seed=N                 use a specific seed to randomize test order
 †  --preserve-it            preserve the `it` variable between examples
@@ -91,6 +92,7 @@ Options:
    --info                   output machine-readable version information and exit
 
 Supported inverted options:
+†  --no-implicit-module-import
 †  --no-randomize-order (default)
 †  --no-preserve-it (default)
 

--- a/src/Test/DocTest/Internal/Options.hs
+++ b/src/Test/DocTest/Internal/Options.hs
@@ -35,6 +35,7 @@ usage = unlines [
   , ""
   , "Options:"
   , "   -jN                      number of threads to use"
+  , "†  --implicit-module-import import module before testing it (default)"
   , "†  --randomize-order        randomize order in which tests are run"
   , "†  --seed=N                 use a specific seed to randomize test order"
   , "†  --preserve-it            preserve the `it` variable between examples"
@@ -45,6 +46,7 @@ usage = unlines [
   , "   --info                   output machine-readable version information and exit"
   , ""
   , "Supported inverted options:"
+  , "†  --no-implicit-module-import"
   , "†  --no-randomize-order (default)"
   , "†  --no-preserve-it (default)"
   , ""
@@ -107,6 +109,9 @@ data ModuleConfig = ModuleConfig
   -- ^ Initialize random number generator used to randomize test cases when
   -- 'cfgRandomizeOrder' is set. If set to 'Nothing', a random seed is picked
   -- from a system RNG source on startup.
+  , cfgImplicitModuleImport :: Bool
+  -- ^ Import a module before testing it. Can be disabled to enabled to test
+  -- non-exposed modules.
   } deriving (Show, Eq, Generic, NFData)
 
 defaultModuleConfig :: ModuleConfig
@@ -114,6 +119,7 @@ defaultModuleConfig = ModuleConfig
   { cfgPreserveIt = False
   , cfgRandomizeOrder = False
   , cfgSeed = Nothing
+  , cfgImplicitModuleImport = True
   }
 
 defaultConfig :: Config
@@ -145,6 +151,8 @@ parseModuleOption config arg =
     "--no-randomize-order" -> Just config{cfgRandomizeOrder=False}
     "--preserve-it" -> Just config{cfgPreserveIt=True}
     "--no-preserve-it" -> Just config{cfgPreserveIt=False}
+    "--implicit-module-import" -> Just config{cfgImplicitModuleImport=True}
+    "--no-implicit-module-import" -> Just config{cfgImplicitModuleImport=False}
     ('-':_) | Just n <- parseSeed arg -> Just config{cfgSeed=Just n}
     _ -> Nothing
 

--- a/test/MainSpec.hs
+++ b/test/MainSpec.hs
@@ -180,3 +180,7 @@ spec = do
     it "sets module level options" $ do
       doctest ["ModuleOptions.Foo"]
         (cases 5)
+
+    it "succeeds for non-exposed modules if --no-implicit-module-import is set" $ do
+      doctest ["NonExposedModule.NoImplicitImport"]
+        (cases 2)

--- a/test/integration/NonExposedModule/Exposed.hs
+++ b/test/integration/NonExposedModule/Exposed.hs
@@ -1,0 +1,3 @@
+module NonExposedModule.Exposed (foo) where
+
+import NonExposedModule.NoImplicitImport (foo)

--- a/test/integration/NonExposedModule/NoImplicitImport.hs
+++ b/test/integration/NonExposedModule/NoImplicitImport.hs
@@ -1,0 +1,10 @@
+module NonExposedModule.NoImplicitImport where
+
+{-# ANN module "doctest-parallel: --no-implicit-module-import" #-}
+
+-- |
+-- >>> import NonExposedModule.Exposed (foo)
+-- >>> foo 7
+-- 14
+foo :: Int -> Int
+foo a = a + a


### PR DESCRIPTION
Make runner omit the usual pre-test module import. This can be used to
test functions from non-exposed modules.

Closes #10