### PR TITLE
With Cabal >= 3.6 remove #ifdef, add GHC=8.2.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: ["macOS", "windows", "ubuntu"]
-        ghc: ["9.2.1", "9.0.1", "8.10.7", "8.8.4", "8.6.5", "8.4.4"]
+        ghc: ["9.2.1", "9.0.1", "8.10.7", "8.8.4", "8.6.5", "8.4.4", "8.2.2"]
         exclude:
           # Windows gets stuck while running the testsuite, but this is not a
           # doctest-parallel failure

--- a/doctest-parallel.cabal
+++ b/doctest-parallel.cabal
@@ -17,7 +17,8 @@ author:         Martijn Bastiaan <martijn@hmbastiaan.nl>
 maintainer:     Martijn Bastiaan <martijn@hmbastiaan.nl>
 build-type:     Simple
 tested-with:
-    GHC == 8.4.4
+    GHC == 8.2.2
+  , GHC == 8.4.4
   , GHC == 8.6.5
   , GHC == 8.8.4
   , GHC == 8.10.7
@@ -86,7 +87,7 @@ library
   other-modules:
       Paths_doctest_parallel
   build-depends:
-      Cabal
+      Cabal >= 3.6
     , Glob
     , base >=4.10 && <5
     , base-compat >=0.7.0
@@ -97,7 +98,7 @@ library
     , exceptions
     , extra
     , filepath
-    , ghc >=8.4 && <9.3
+    , ghc >=8.2 && <9.3
     , ghc-paths >=0.1.0.9
     , pretty
     , process

--- a/src/Test/DocTest/Helpers.hs
+++ b/src/Test/DocTest/Helpers.hs
@@ -41,10 +41,7 @@ import Distribution.Types.ConfVar (ConfVar(..))
 import Distribution.Types.Version (Version, mkVersion')
 import Distribution.Types.VersionRange (withinRange)
 import Distribution.Verbosity (silent)
-
-#if MIN_VERSION_Cabal(3,6,0)
 import Distribution.Utils.Path (SourceDir, PackageDir, SymbolicPath)
-#endif
 
 
 -- | Efficient implementation of set like deletion on lists
@@ -176,7 +173,7 @@ solveCondTree CondNode{condTreeData, condTreeConstraints, condTreeComponents} =
             GHC -> withinRange buildGhc versionRange
             _   -> error ("Unrecognized compiler: " <> show cf)
         -- XXX: We currently ignore any flags passed to Cabal
-        Flag _fn -> False
+        PackageFlag _fn -> False
     Lit b -> b
     CNot con -> not (goCondition con)
     COr con0 con1 -> goCondition con0 || goCondition con1

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,6 @@ resolver:
 
 packages:
 - .
+
+extra-deps:
+- Cabal-3.6.3.0@sha256:ff97c442b0c679c1c9876acd15f73ac4f602b973c45bde42b43ec28265ee48f4,12459


### PR DESCRIPTION
I tested and found this worked well if I constrained `Cabal >= 3.6`. That way we have the best chance of parsing `.cabal` files and at the same time we can throw away a `CPP #ifdef`. I found this worked for me 8.2.2 <= GHC <= 9.2.2