### PR TITLE
Use `abs` in QuickCheck example

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,6 +1,7 @@
 # Unreleased
   * `getNumProcessors` is now used to detect the (default) number of GHCi subprocesses to spawn. This should more reliably use all of a system's resources. Fixes [#53](https://github.com/martijnbastiaan/doctest-parallel/issues/53).
   * Add Nix support. If the environment variable `NIX_BUILD_TOP` is present an extra package database is added to `GHC_PACKAGE_PATH`. This isn't expected to break existing builds, but if it does consider passing `--no-nix`. ([#34](https://github.com/martijnbastiaan/doctest-parallel/issues/34))
+  * The QuickCheck example mentioned in the README now uses `abs` instead of `sort`. This prevents confusing errors when `sort` is not imported. Fixes [#50](https://github.com/martijnbastiaan/doctest-parallel/issues/50).
 
 # 0.2.5
   * Loosen Cabal bounds to >= 2.4 && < 3.9

--- a/README.markdown
+++ b/README.markdown
@@ -195,14 +195,14 @@ verify properties with QuickCheck.  A simple property looks like this:
 
 ```haskell
 -- |
--- prop> \xs -> sort xs == (sort . sort) (xs :: [Int])
+-- prop> \n -> abs n == abs (abs (n :: Int))
 ```
 
 The lambda abstraction is optional and can be omitted:
 
 ```haskell
 -- |
--- prop> sort xs == (sort . sort) (xs :: [Int])
+-- prop> abs n == abs (abs (n :: Int))
 ```
 
 A complete example that uses setup code is below:


### PR DESCRIPTION
Fixes #50