### PR TITLE
Add support for Nix shell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,13 @@ jobs:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: |
         nix-build
-        cd test/nix && nix-build
+
+        cd test/nix
+        nix-build
+        nix-shell --pure --run "cabal run doctests"
+        nix-shell --pure --run "cabal test"
+        nix-shell --pure --run "cabal run doctests --write-ghc-environment-files=always"
+        nix-shell --pure --run "cabal test --write-ghc-environment-files=always"
 
   # Mandatory check on GitHub
   all:

--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -1,3 +1,6 @@
+# Unreleased
+ * Add support for Nix shell environments ([#58](https://github.com/martijnbastiaan/doctest-parallel/pull/58))
+
 # 0.2.6
   * `getNumProcessors` is now used to detect the (default) number of GHCi subprocesses to spawn. This should more reliably use all of a system's resources. Fixes [#53](https://github.com/martijnbastiaan/doctest-parallel/issues/53).
   * Add Nix support. If the environment variable `NIX_BUILD_TOP` is present an extra package database is added to `GHC_PACKAGE_PATH`. This isn't expected to break existing builds, but if it does consider passing `--no-nix`. ([#34](https://github.com/martijnbastiaan/doctest-parallel/issues/34))

--- a/doctest-parallel.cabal
+++ b/doctest-parallel.cabal
@@ -76,6 +76,7 @@ library
       Test.DocTest.Internal.GhcUtil
       Test.DocTest.Internal.Interpreter
       Test.DocTest.Internal.Location
+      Test.DocTest.Internal.Nix
       Test.DocTest.Internal.Options
       Test.DocTest.Internal.Parse
       Test.DocTest.Internal.Property

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{ nixpkgs ? import ./nix/nixpkgs.nix {} }:
+let
+  inherit (nixpkgs) pkgs;
+  inherit (pkgs) haskellPackages;
+
+  project = (import ./. {});
+in
+pkgs.stdenv.mkDerivation {
+  name = "shell";
+  buildInputs = project.env.propagatedBuildInputs ++ project.env.nativeBuildInputs ++ [
+    haskellPackages.cabal-install
+  ];
+  LC_ALL = "C.UTF-8";
+}

--- a/src/Test/DocTest/Internal/Nix.hs
+++ b/src/Test/DocTest/Internal/Nix.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Test.DocTest.Internal.Nix where
+
+import Control.Monad.Extra (ifM, msum)
+import Control.Monad.Trans.Maybe
+import Data.Bool (bool)
+import Data.List (intercalate, isSuffixOf)
+import Data.Maybe (isJust)
+import Data.Version
+import GHC.Base (mzero)
+import System.Directory
+import System.Environment (lookupEnv)
+import System.FilePath ((</>), isDrive, takeDirectory)
+import System.Process (readProcess)
+
+#if __GLASGOW_HASKELL__ >= 900
+import GHC.Data.Maybe (liftMaybeT)
+import System.Info (fullCompilerVersion)
+#else
+import Maybes (liftMaybeT)
+import System.Info (compilerVersion)
+
+fullCompilerVersion :: Version
+fullCompilerVersion =
+  case compilerVersion of
+    Version majorMinor tags ->
+      Version (majorMinor ++ [lvl1]) tags
+ where
+  lvl1 :: Int
+  lvl1 = __GLASGOW_HASKELL_PATCHLEVEL1__
+#endif
+
+-- | E.g. @9.0.2@
+compilerVersionStr :: String
+compilerVersionStr = intercalate "." (map show (versionBranch fullCompilerVersion))
+
+-- | Traverse upwards until one of the following conditions is met:
+--
+--   * Current working directory is either root or a home directory
+--   * The predicate function returns 'Just'
+--
+findDirectoryUp :: (FilePath -> IO (Maybe a)) -> MaybeT IO a
+findDirectoryUp f = do
+  home <- liftMaybeT getHomeDirectory
+  MaybeT (go home =<< getCurrentDirectory)
+ where
+  go home cwd
+    | isDrive cwd = pure Nothing
+    | cwd == home = pure Nothing
+    | otherwise =
+      f cwd >>= \case
+        Just a -> pure (Just a)
+        Nothing -> go home (takeDirectory cwd)
+
+-- | Like 'findDirectoryUp', but takes a predicate function instead. If the predicate
+-- yields 'True', the filepath is returned.
+findDirectoryUpPredicate :: (FilePath -> IO Bool) -> MaybeT IO FilePath
+findDirectoryUpPredicate f = findDirectoryUp (\fp -> bool Nothing (Just fp) <$> f fp)
+
+-- | Find the root of the Cabal project relative to the current directory.
+findCabalProjectRoot :: MaybeT IO FilePath
+findCabalProjectRoot =
+  msum
+    [ findDirectoryUpPredicate containsCabalProject
+    , findDirectoryUpPredicate containsCabalPackage
+    ]
+ where
+  containsCabalPackage :: FilePath -> IO Bool
+  containsCabalPackage fp = elem "cabal.project" <$> getDirectoryContents fp
+
+  containsCabalProject :: FilePath -> IO Bool
+  containsCabalProject fp = any (".cabal" `isSuffixOf`) <$> getDirectoryContents fp
+
+-- | Find the local package database in @dist-newstyle@.
+findLocalPackageDb :: MaybeT IO FilePath
+findLocalPackageDb = do
+  projectRoot <- findCabalProjectRoot
+  let
+    relDir = "dist-newstyle" </> "packagedb" </> ("ghc-" ++ compilerVersionStr)
+    absDir = projectRoot </> relDir
+  ifM
+    (liftMaybeT (doesDirectoryExist absDir))
+    (return absDir)
+    mzero
+
+-- | Are we running in a Nix shell?
+inNixShell :: IO Bool
+inNixShell = isJust <$> lookupEnv "IN_NIX_SHELL"
+
+-- | Are we running in a Nix build environment?
+inNixBuild :: IO Bool
+inNixBuild = isJust <$> lookupEnv "NIX_BUILD_TOP"
+
+getLocalCabalPackageDbArgs :: IO [String]
+getLocalCabalPackageDbArgs = do
+  runMaybeT findLocalPackageDb >>= \case
+     Nothing -> pure []
+     Just s -> pure ["-package-db", s]
+
+getLocalNixPackageDbArgs :: IO [String]
+getLocalNixPackageDbArgs = do
+  pkgDb <- makeAbsolute ("dist" </> "package.conf.inplace")
+  ifM
+    (doesDirectoryExist pkgDb)
+    (pure ["-package-db", pkgDb])
+    (pure [])
+
+-- | Get global package db; used in a NIX_SHELL context
+getGlobalPackageDb :: IO String
+getGlobalPackageDb = init <$> readProcess "ghc" ["--print-global-package-db"] ""
+
+-- | Get flags to be used when running in a Nix context (either in a build, or a
+-- shell).
+getNixGhciArgs :: IO [String]
+getNixGhciArgs =
+  ifM inNixShell goShell (ifM inNixBuild goBuild (pure []))
+ where
+  goShell = do
+    globalPkgDb <- getGlobalPackageDb
+    localPkgDbFlag <- getLocalCabalPackageDbArgs
+    let globalDbFlag = ["-package-db", globalPkgDb]
+    pure (defaultArgs ++ globalDbFlag ++ localPkgDbFlag)
+
+  goBuild = do
+    localDbFlag <- getLocalNixPackageDbArgs
+    pure (defaultArgs ++ localDbFlag)
+
+  defaultArgs =
+    [ "-package-env", "-"
+
+    -- Nix doesn't always expose the GHC library (_specifically_ the GHC lib) even
+    -- if a package lists it as a dependency. This simply always exposes it as a
+    -- workaround.
+    , "-package", "ghc"
+    ]

--- a/test/nix/a.cabal
+++ b/test/nix/a.cabal
@@ -1,17 +1,18 @@
+cabal-version:    2.2
 name:             a
 version:          0.0.0
 build-type:       Simple
-cabal-version:    >= 1.8
 
 library
   hs-source-dirs:   src
   exposed-modules:  A
-  build-depends:    base, ghc
+  build-depends:    base, extra, ghc
+  default-language: Haskell2010
 
 test-suite doctests
   type:             exitcode-stdio-1.0
   hs-source-dirs:   test
   main-is:          doctests.hs
   ghc-options:      -threaded
-  build-depends:    base, a, doctest-parallel >= 0.1
+  build-depends:    base, a, doctest-parallel >= 0.1,
   default-language: Haskell2010

--- a/test/nix/cabal.project
+++ b/test/nix/cabal.project
@@ -1,0 +1,5 @@
+packages:
+  .
+
+-- Nix projects don't need environment files!
+write-ghc-environment-files: never

--- a/test/nix/release.nix
+++ b/test/nix/release.nix
@@ -1,0 +1,4 @@
+let
+  pkgs = import ./nix/nixpkgs.nix { };
+in
+  pkgs.haskellPackages.callPackage ./default.nix { }

--- a/test/nix/shell.nix
+++ b/test/nix/shell.nix
@@ -1,0 +1,14 @@
+{ nixpkgs ? import ./nix/nixpkgs.nix {} }:
+let
+  inherit (nixpkgs) pkgs;
+  inherit (pkgs) haskellPackages;
+
+  project = import ./release.nix;
+in
+pkgs.stdenv.mkDerivation {
+  name = "shell";
+  buildInputs = project.env.propagatedBuildInputs ++ project.env.nativeBuildInputs ++ [
+    haskellPackages.cabal-install
+  ];
+  LC_ALL = "C.UTF-8";
+}

--- a/test/nix/src/A.hs
+++ b/test/nix/src/A.hs
@@ -2,6 +2,7 @@
 
 module A where
 
+-- Test CPP on 'ghc', which seems to be handled specially
 #if MIN_VERSION_ghc(9,0,0)
 -- #if MIN_VERSION_base(4,15,0)
 -- |
@@ -13,4 +14,18 @@ foo = 23
 -- >>> bar
 -- 42
 bar = 42
+#endif
+
+-- Test CPP on 'base', a wired-in package
+#if MIN_VERSION_base(4,12,0)
+x = 3
+#else
+x = 5
+#endif
+
+-- Test CPP on 'extra', a "normal" Hackage package
+#if MIN_VERSION_extra(1,7,0)
+y = 10
+#else
+y = 20
 #endif


### PR DESCRIPTION
Integrating `doctest-parallel` over at https://github.com/clash-lang/stack-templates/pull/22 showed that it doesn't handle Nix shell environments correctly. This PR rectifies that.