### PR TITLE
replace `ghc` dependency with `ghc-lib`

### DIFF
--- a/doctest-parallel.cabal
+++ b/doctest-parallel.cabal
@@ -100,7 +100,7 @@ library
     , directory
     , exceptions
     , filepath
-    , ghc >=8.2 && <9.5
+    , ghc-lib >=8.2 && <9.5
     , ghc-paths >=0.1.0.9
     , process
     , random >= 1.2
@@ -204,7 +204,7 @@ test-suite spectests
     , directory
     , exceptions
     , filepath
-    , ghc
+    , ghc-lib
     , ghc-paths >=0.1.0.9
     , hspec >=2.3.0
     , hspec-core >=2.3.0


### PR DESCRIPTION
I think this may solve an issue: https://github.com/input-output-hk/haskell.nix/issues/1829#issue-1534542637
```
DocTests: <command line>: cannot satisfy -package ghc
```

https://hackage.haskell.org/package/ghc-lib

I will confirm shortly if it actually solves the issue. Thanks