### PR TITLE
Allow Cabal-3.10 and bump CI to GHC 9.6.1, 9.4.4 and 9.2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: ["macOS-latest", "windows-latest", "ubuntu-22.04"]
-        resolver: ["lts-20.04"]
+        resolver: ["lts-20.17"]
       fail-fast: false
     steps:
       - name: Checkout
@@ -62,26 +62,18 @@ jobs:
     strategy:
       matrix:
         os: ["macOS-latest", "windows-latest", "ubuntu-22.04"]
-        ghc: ["9.4.3", "9.2.5", "9.0.2", "8.10.7", "8.8.4", "8.6.5", "8.4.4", "8.2.2"]
+        ghc: ["9.6.1", "9.4.4", "9.2.7", "9.0.2", "8.10.7", "8.8.4", "8.6.5", "8.4.4", "8.2.2"]
         exclude:
           # Windows gets stuck while running the testsuite, but this is not a
           # doctest-parallel failure
           - os: windows-latest
             ghc: 8.8.4
 
-          # Chocolaty fails, see https://github.com/haskell/actions/issues/129
-          - os: windows-latest
-            ghc: 9.4.3
-
-          # Chocolaty fails, see https://github.com/haskell/actions/issues/129
-          - os: windows-latest
-            ghc: 9.2.5
-
-        # Uncomment if testing with an unreleased GHC. Make sure to edit the
-        #  "Setup Haskell (head)" step too.
-        include:
-          - os: ubuntu-22.04
-            ghc: head
+        # # Uncomment if testing with an unreleased GHC. Make sure to edit the
+        # #  "Setup Haskell (head)" step too.
+        # include:
+        #   - os: ubuntu-22.04
+        #     ghc: head
       fail-fast: false
     steps:
       - name: Checkout

--- a/doctest-parallel.cabal
+++ b/doctest-parallel.cabal
@@ -23,9 +23,10 @@ tested-with:
   , GHC == 8.8.4
   , GHC == 8.10.7
   , GHC == 9.0.2
-  , GHC == 9.2.5
-  , GHC == 9.4.3
+  , GHC == 9.2.7
+  , GHC == 9.4.4
   , GHC == 9.6.1
+
 extra-source-files:
     example/example.cabal
     example/src/Example.hs
@@ -91,7 +92,7 @@ library
       Data.List.Extra
       Paths_doctest_parallel
   build-depends:
-      Cabal >= 2.4 && < 3.10
+      Cabal >= 2.4 && < 3.11
     , Glob
     , base >=4.10 && <5
     , base-compat >=0.7.0
@@ -196,9 +197,9 @@ test-suite spectests
   build-depends:
       HUnit
     , QuickCheck >=2.13.1
-    , base >=4.5 && <5
-    , base-compat >=0.7.0
-    , code-page >=0.1
+    , base
+    , base-compat
+    , code-page
     , containers
     , doctest-parallel
     , deepseq
@@ -206,7 +207,7 @@ test-suite spectests
     , exceptions
     , filepath
     , ghc
-    , ghc-paths >=0.1.0.9
+    , ghc-paths
     , hspec >=2.3.0
     , hspec-core >=2.3.0
     , mockery
@@ -215,6 +216,6 @@ test-suite spectests
     , silently >=1.2.4
     , stringbuilder >=0.4
     , spectests-modules
-    , syb >=0.3
+    , syb
     , transformers
   default-language: Haskell2010


### PR DESCRIPTION
- bump to `Cabal < 3.11`
- remove redundant bounds in test-suites (implied by bounds on library)
- Update cabal CI to latest GHCs

Fixes #68.
- #68