### PR TITLE
fix: Use GHCs "runhaskell" instead of "cabal" for test

### DIFF
--- a/doctest-parallel.cabal
+++ b/doctest-parallel.cabal
@@ -65,6 +65,11 @@ source-repository head
   type: git
   location: https://github.com/martijnbastiaan/doctest-parallel
 
+flag runhaskell
+  Description: Use runhaskell instead of cabal for tests
+  Default: False
+  Manual: True
+
 library
   ghc-options: -Wall
   hs-source-dirs: src
@@ -221,3 +226,6 @@ test-suite spectests
     , syb
     , transformers
   default-language: Haskell2010
+
+  if flag(runhaskell)
+    cpp-options: -DUSE_RUNHASKELL

--- a/test/ProjectsSpec.hs
+++ b/test/ProjectsSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 
 module ProjectsSpec (main, spec) where
@@ -24,6 +25,11 @@ spec = do
         | otherwise -> describe
 
   cDescribe "T85-default-language" $ do
+#ifdef USE_RUNHASKELL
+    it "runhaskell Setup test doctests" $ do
+      _ <- readCreateProcess (proc "runhaskell" ["Setup", "test", "doctests"]) ""
+#else
     it "cabal run doctests" $ do
       _ <- readCreateProcess (proc "cabal" ["run", "-v0", "--", "doctests", "--quiet"]) ""
+#endif
       pure ()


### PR DESCRIPTION
`runhaskell` is the internal command used by the `cabal` command. This avoids a dependence on `cabal-install`.

Solves #97 