### PR TITLE
fix: CI

### DIFF
--- a/.github/scripts/all_check.py
+++ b/.github/scripts/all_check.py
@@ -11,18 +11,29 @@ Makes sure:
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import networkx as nx
 import sys
 import yaml
 
 CI_PATH = ".github/workflows/ci.yml"
 ALL_TEST = "all"
 
+def get_needs(job_data):
+  needs = job_data.get("needs", ())
+  if not isinstance(needs, list):
+    needs = [needs]
+  return needs
+
 def main():
   ci_yml_fp = open(CI_PATH, "r")
   ci_yml_parsed = yaml.load(ci_yml_fp, Loader=yaml.FullLoader)
 
-  all_jobs = set(ci_yml_parsed['jobs'].keys()) - {ALL_TEST}
-  all_needs = set(ci_yml_parsed["jobs"][ALL_TEST]["needs"])
+  needs_graph = nx.DiGraph()
+  needs_graph.add_nodes_from((job, {"needs" : get_needs(data)}) for job, data in ci_yml_parsed['jobs'].items())
+  needs_graph.add_edges_from([(j, n) for j, d in needs_graph.nodes(data=True) for n in d["needs"]])
+
+  all_jobs = set(needs_graph.nodes) - {ALL_TEST}
+  all_needs = set(nx.descendants(needs_graph, ALL_TEST))
 
   if all_jobs - all_needs:
     sys.exit(f"Not all jobs mentioned in {ALL_TEST}.needs: {all_jobs - all_needs}")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
+          sudo apt-get -y install python3-networkx
           sudo apt-get -y install python3-yaml
 
       - name: Check that the 'all' job depends on all other jobs


### PR DESCRIPTION
The `cabal` job has a dependency on `generate-ghc-matrix`, which counts as a job, but is not included in the `needs` of the `all` job. This was added in b25417e19bc0066004ee98941dc2841ab969153d.

Transitive dependencies are not really an issue, because them failing will fail their dependent jobs too. So this PR creates a dependency tree using `networkx` and ensures that all jobs are at least transitively depended on by the `all` job.